### PR TITLE
Assignment 1.4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "editor.formatOnSave": true,
+    "python.defaultInterpreterPath": "/home/madhu/miniconda3/envs/mle-dev/bin",
+    "python.formatting.blackArgs": [
+        "--line-length=88"
+    ],
+    "isort.args": [
+        "--profile",
+        "black"
+    ],
+    "python.linting.flake8Args": [
+        "--max-line-length=88",
+    ],
+    "isort.path": [
+        "/home/madhu/miniconda3/envs/mle-dev/bin/isort"
+    ]
+}


### PR DESCRIPTION
Closes #6 

- Configured vscode user and workspace settings with the formatting tools as mentioned.
- Attached the workspace settings.json content.


```json
{
    "editor.formatOnSave": true,
    "python.defaultInterpreterPath": "/home/madhu/miniconda3/envs/mle-dev/bin",
    "python.formatting.blackArgs": [
        "--line-length=88"
    ],
    "isort.args": [
        "--profile",
        "black"
    ],
    "python.linting.flake8Args": [
        "--max-line-length=88",
    ],
    "isort.path": [
        "/home/madhu/miniconda3/envs/mle-dev/bin/isort"
    ]
}
```